### PR TITLE
Add account balance tracking and page

### DIFF
--- a/app/accounts/page.tsx
+++ b/app/accounts/page.tsx
@@ -1,0 +1,43 @@
+import prisma from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+export default async function AccountsPage() {
+  const accounts = await prisma.account.findMany({
+    select: {
+      id: true,
+      name: true,
+      balanceMinor: true,
+      currencyCode: true,
+    },
+    orderBy: { name: 'asc' },
+  })
+
+  return (
+    <main className="p-6 mx-auto max-w-xl">
+      <h1 className="text-2xl font-semibold mb-4">Accounts</h1>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left border-b py-2">Name</th>
+            <th className="text-right border-b py-2">Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {accounts.map((acc) => (
+            <tr key={acc.id}>
+              <td className="py-2 border-b">{acc.name}</td>
+              <td className="py-2 border-b text-right">
+                {new Intl.NumberFormat('en-US', {
+                  style: 'currency',
+                  currency: acc.currencyCode,
+                }).format(acc.balanceMinor / 100)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  )
+}
+

--- a/prisma/migrations/20250831071420_add_account_balance/migration.sql
+++ b/prisma/migrations/20250831071420_add_account_balance/migration.sql
@@ -1,0 +1,45 @@
+-- AlterTable
+ALTER TABLE "account" ADD COLUMN "balanceMinor" INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill existing balances
+UPDATE "account" a
+SET "balanceMinor" = COALESCE((
+  SELECT SUM(
+    CASE WHEN t."direction" = 'credit' THEN t."amountMinor" ELSE -t."amountMinor" END
+  )
+  FROM "transaction" t
+  WHERE t."accountId" = a."id"
+), 0);
+
+-- Function to maintain account balance on changes
+CREATE OR REPLACE FUNCTION update_account_balance() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE "account"
+    SET "balanceMinor" = "balanceMinor" + CASE WHEN NEW."direction" = 'credit' THEN NEW."amountMinor" ELSE -NEW."amountMinor" END
+    WHERE "id" = NEW."accountId";
+    RETURN NEW;
+  ELSIF TG_OP = 'UPDATE' THEN
+    UPDATE "account"
+    SET "balanceMinor" = "balanceMinor"
+      + CASE WHEN NEW."direction" = 'credit' THEN NEW."amountMinor" ELSE -NEW."amountMinor" END
+      - CASE WHEN OLD."direction" = 'credit' THEN OLD."amountMinor" ELSE -OLD."amountMinor" END
+    WHERE "id" = NEW."accountId";
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE "account"
+    SET "balanceMinor" = "balanceMinor" - CASE WHEN OLD."direction" = 'credit' THEN OLD."amountMinor" ELSE -OLD."amountMinor" END
+    WHERE "id" = OLD."accountId";
+    RETURN OLD;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to keep account balance up to date
+DROP TRIGGER IF EXISTS trg_update_account_balance ON "transaction";
+
+CREATE TRIGGER trg_update_account_balance
+AFTER INSERT OR UPDATE OR DELETE ON "transaction"
+FOR EACH ROW EXECUTE FUNCTION update_account_balance();
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,7 @@ model Account {
   status              String      @default("active")
   openedAt            DateTime?
   closedAt            DateTime?
+  balanceMinor        Int         @default(0)
 
   transactions        Transaction[]
 


### PR DESCRIPTION
## Summary
- track account balances with balanceMinor field
- auto-update balances via trigger when transactions change
- display accounts and balances on new /accounts page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx prisma generate` *(fails: Failed to fetch sha256 checksum)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc547ee1c8832c87d9da25a01d4bb4